### PR TITLE
Document support for `cf restage` in v0.3.0

### DIFF
--- a/supported-cf-cli-commands.md
+++ b/supported-cf-cli-commands.md
@@ -107,7 +107,7 @@ The Application Service Adapter supports a subset of the Cloud Foundry manifest 
 |`cf stop` | Y |     |
 |`cf restart` | Y |     |
 |`cf stage-package` | Y |     |
-|`cf restage` | N |     |
+|`cf restage` | Y | Using `--strategy` flag is not supported.    |
 |`cf restart-app-instance` | N |     |
 |`cf run-task` | N |     |
 |`cf tasks` | N |     |


### PR DESCRIPTION
Updated supported-cf-cli document. Jira Story - https://jira.eng.vmware.com/browse/TME-1556