### PR TITLE
Document support  for `cf env`, `cf set-env` & `cf unset-env` in v0.3.0

### DIFF
--- a/supported-cf-cli-commands.md
+++ b/supported-cf-cli-commands.md
@@ -119,9 +119,9 @@ The Application Service Adapter supports a subset of the Cloud Foundry manifest 
 |`cf download-droplet` | N |     |
 |`cf events` | N |     |
 |`cf logs` | N |     |
-|`cf env` | N |     |
-|`cf set-env` | N |     |
-|`cf unset-env` | N |     |
+|`cf env` | Y | Fetching `system-provided`, `running` & `staging` env variables are not supported.   |
+|`cf set-env` | Y |     |
+|`cf unset-env` | Y |     |
 |`cf stacks` | N |     |
 |`cf stack` | N |     |
 |`cf copy-source` | N |     |


### PR DESCRIPTION
Jira story: [TME-1560](https://jira.eng.vmware.com/browse/TME-1560), [TME-1527](https://jira.eng.vmware.com/browse/TME-1527)
