### PR TITLE
Remove scaling parameters for kube-rbac-proxy

### DIFF
--- a/install.md
+++ b/install.md
@@ -245,8 +245,6 @@ To configure the installation settings:
         ... #! scaling keys are the same as above
       korifi_statefulset_runner:
         ... #! scaling keys are the same as above
-      kube_rbac_proxy:
-        ... #! scaling keys are the same as above, minus the "replicas" key
       cartographer_builder_runner:
         ... #! scaling keys are the same as above
       telemetry_informer:


### PR DESCRIPTION
For versions > v0.10.0 we no longer include the kube-rbac-proxy container in our deployments, so we have removed the scaling parameter for it.

You may want to wait until v0.10.0 is shipped before merging this change, since that version still includes the parameter.