### PR TITLE
Revert "Remove scaling parameters for kube-rbac-proxy"

### DIFF
--- a/install.md
+++ b/install.md
@@ -245,6 +245,8 @@ To configure the installation settings:
         ... #! scaling keys are the same as above
       korifi_statefulset_runner:
         ... #! scaling keys are the same as above
+      kube_rbac_proxy:
+        ... #! scaling keys are the same as above, minus the "replicas" key
       cartographer_builder_runner:
         ... #! scaling keys are the same as above
       telemetry_informer:


### PR DESCRIPTION
Reverts pivotal/docs-tas-adapter#39

- Missed the section on waiting until after 0.10 ships