### PR TITLE
Add Architecture link to Concepts page

### DIFF
--- a/concepts.md
+++ b/concepts.md
@@ -2,5 +2,6 @@
 
 This topic collects documentation on Application Service Adapter system concepts, including the following:
 
+* [Architecture](technical-architecture.md)
 * [User authentication overview](user-authentication-overview.md)
 


### PR DESCRIPTION
Updated `concepts.md` with suggested change from @julian-hj  on jira rejection comment.
