### PR TITLE
Add missing docs for `api_ingress.port` setting

### DIFF
--- a/install.md
+++ b/install.md
@@ -301,6 +301,8 @@ To configure the installation settings:
         data: |
           API-AUTH-PROXY-TLS-CRT
       host: "API-AUTH-PROXY-FQDN"
+    api_ingress:
+      port: "API-PORT"
     app_registry:
       ca_cert:
         data: |
@@ -339,6 +341,7 @@ To configure the installation settings:
 
    - `API-AUTH-PROXY-TLS-CRT` is the CA certificate from the authentication proxy running along side your Kubernetes cluster.
    - `API-AUTH-PROXY-FQDN` is the FQDN for the authentication proxy running along side your Kubernetes cluster.
+   - `API-PORT` is the port number to listen on for CF API server requests. When set to `0` or left unspecified, returned URLs do not include a port and the server listens on the default (443) port.
    - `PEM-ENCODED-CERTIFICATE-CONTENTS` is a PEM encoded multiline string containing the certificate authority (CA) certificate.
        - The value must be inserted into your values file as a YAML multiline string with a block scalar literal.
    - `KPACK-CLUSTER-BUILDER-NAME` is the name of the kpack cluster builder to use for staging. Tanzu Build Service provides two cluster builders named `base` and `default`. To create your own builder, see [Managing Builders](https://docs.vmware.com/en/Tanzu-Build-Service/1.3/vmware-tanzu-build-service-v13/GUID-managing-builders.html) in the Tanzu Build Service documentation, and update this setting with the corresponding builder name.

--- a/install.md
+++ b/install.md
@@ -341,7 +341,7 @@ To configure the installation settings:
 
    - `API-AUTH-PROXY-TLS-CRT` is the CA certificate from the authentication proxy running along side your Kubernetes cluster.
    - `API-AUTH-PROXY-FQDN` is the FQDN for the authentication proxy running along side your Kubernetes cluster.
-   - `API-PORT` is the port number to listen on for CF API server requests. When set to `0` or left unspecified, returned URLs do not include a port and the server listens on the default (443) port.
+   - `API-PORT` is the port number which clients should use to connect to the Application Service Adapter API, and which the API will include in URLs that direct back to itself. When set to `0` or left unset, no port is included in those URLs, and clients should connect to port 443, the standard port for HTTPS traffic.
    - `PEM-ENCODED-CERTIFICATE-CONTENTS` is a PEM encoded multiline string containing the certificate authority (CA) certificate.
        - The value must be inserted into your values file as a YAML multiline string with a block scalar literal.
    - `KPACK-CLUSTER-BUILDER-NAME` is the name of the kpack cluster builder to use for staging. Tanzu Build Service provides two cluster builders named `base` and `default`. To create your own builder, see [Managing Builders](https://docs.vmware.com/en/Tanzu-Build-Service/1.3/vmware-tanzu-build-service-v13/GUID-managing-builders.html) in the Tanzu Build Service documentation, and update this setting with the corresponding builder name.


### PR DESCRIPTION
- Documentation was missing for a port configuration that exists in the 1.0.0 version of our product.
- This change belongs in both the main branch and also 1.0 docs.