### PR TITLE
Update troubleshooting docs

### DIFF
--- a/supported-cf-cli-commands.md
+++ b/supported-cf-cli-commands.md
@@ -153,27 +153,31 @@ This section describes the org and space operations that Application Service Ada
 
 ### Org operations
 
-| Command | Supported? | Notes |
-|---------|------------|-------|
-|`cf orgs`| Y |   |
-|`cf org`| Y | Using the `--guid` flag to retrieve the GUID of the org is supported.<br/>Using the command without the `--guid` flag is not supported.  |
-|`cf create-org`| Y |   |
-|`cf delete-org`| Y |   |
-|`cf rename-org`| N |   |
+| Command             | Supported? | Notes |
+|---------------------|------------|-------|
+| `cf orgs`           | Y          |   |
+| `cf org`            | Y          | Using the `--guid` flag to retrieve the GUID of the org is supported.<br/>Using the command without the `--guid` flag is not supported.  |
+| `cf create-org`     | Y          |   |
+| `cf delete-org`     | Y          |   |
+| `cf rename-org`     | N          |   |
+| `cf set-org-role`   | Y     |   |
+| `cf unset-org-role` | Y     |   |
 
 ### Space operations
 
-| Command | Supported? | Notes |
-|---------|------------|-------|
-|`cf spaces`| Y |   |
-|`cf space`| Y | Using the `--guid` flag to retrieve the GUID of the space is supported.<br/>Using the command without the `--guid` flag is not supported. |
-|`cf create-space`| Y |   |
-|`cf delete-space`| Y |   |
-|`cf rename-space`| N |   |
-|`cf apply-manifest`| Y |   |
-|`cf allow-space-ssh`| N |   |
-|`cf disallow-space-ssh`| N |   |
-|`cf space-ssh-allowed`| N |   |
+| Command                 | Supported? | Notes |
+|-------------------------|------------|-------|
+| `cf spaces`             | Y |   |
+| `cf space`              | Y | Using the `--guid` flag to retrieve the GUID of the space is supported.<br/>Using the command without the `--guid` flag is not supported. |
+| `cf create-space`       | Y |   |
+| `cf delete-space`       | Y |   |
+| `cf rename-space`       | N |   |
+| `cf apply-manifest`     | Y |   |
+| `cf allow-space-ssh`    | N |   |
+| `cf disallow-space-ssh` | N |   |
+| `cf space-ssh-allowed`  | N |   |
+| `cf set-space-role`     | Y     |   |
+| `cf unset-space-role`   | Y     |   |
 
 
 ## <a id="route-domain-operations"></a> Route and domain operations

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -207,6 +207,26 @@ Creating org my-org as cf-admin...
 1. Verify that there is a RoleBinding in the `cf` namespace binding the `korifi-controllers-admin` ClusterRole to the given user and that it has the `cloudfoundry.org/propagate-cf-role: "true"` annotation.
 1. If that RoleBinding does not exist, either switch to a user that is bound to the `korifi-controllers-admin` ClusterRole or create a RoleBinding as a cluster admin.
 
+### Dev User unauthorized to target an Org or Space
+#### Symptom
+When I first login `cf login` and/or
+when I run `cf target -o my-org -s my-space`, the following error message is returned:
+```bash
+No org or space targeted, use 'cf target -o ORG -s SPACE'
+You are not authorized to perform the requested action
+FAILED
+```
+#### Possible Causes
+The user targeting the Org or Space is not bound to the following ClusterRoles:
+`korifi-controllers-root-namespace-user` in the root namespace (from the installation values file)
+`korifi-controllers-organization-user` in the cf-org namespace `cf-org-<ORG_GUID>` 
+`korifi-controllers-space-developer` in the cf-space namespace `cf-space-<SPACE_GUID>`
+
+#### Troubleshooting Steps/Potential Solutions
+1. Fetch the name of the user in the `cf curl /whoami` command output.
+1. Check RoleBindings in each of the namespaces with the name of that user as a Subject
+1. If the rolebindings do not exist, create them with cf set-role commands
+
 ### Pushing an app fails to build an image
 #### Symptom
 When I run `cf push`, the CF CLI does not respond with a built image.


### PR DESCRIPTION
Updates user rolebinding issues based on interrupt where roles were set up manually with kubernetes yaml instead of through cf commands.

Also update list of supported cf commands to include the cf role management commands.

Co-authored-by: Andrew Costa <ancosta@vmware.com>
Co-authored-by: Ashwin Krishna <krishnaas@vmware.com>