### PR TITLE
Add link to TOC for air-gapped installation docs

### DIFF
--- a/toc.md
+++ b/toc.md
@@ -7,6 +7,7 @@ This is the table of contents from which the Application Service Adapter for Tan
 - [Reference architecture](reference-architecture.md)
 - [Installing prerequisites](install-prerequisites.md)
 - [Installing Application Service Adapter](install.md)
+  - [Installing to air-gapped environments](install-to-air-gapped.md) 
 - [Getting started with Application Service Adapter](getting-started.md)
   - [Push the spring-music sample application](push-spring-music.md)
 - [Administering Application Service Adapter](administering.md)


### PR DESCRIPTION
I noticed that these docs weren't linked to in the TOC. This should make them more discoverable.

We may also consider adding a note to the regular installation docs that links out to these as well.