### PR TITLE
Fix default value for kubernetes version

### DIFF
--- a/install.md
+++ b/install.md
@@ -335,7 +335,7 @@ To configure Application Service Adapter for installation on OpenShift:
      kubernetes_version: "KUBERNETES-VERSION"
    ```
 
-   Where `KUBERNETES-VERSION` is the Kubernetes version of the cluster. Default is v1.23.3.
+   Where `KUBERNETES-VERSION` is the Kubernetes version of the cluster. Default is `1.23.3`.
 
 ### <a id="aws-iam-registry-auth"></a>(Optional) Use AWS IAM authentication for registry credentials
 


### PR DESCRIPTION
Value needs to contain only `digits` and `.` for `kubenetes_version` key.

We should cheery pick this merge into `release/1.1` branch