### PR TITLE
Document the ability to set the service label of an UPSI

### DIFF
--- a/environment-variables.md
+++ b/environment-variables.md
@@ -130,7 +130,7 @@ Application Service Adapter returns the results as a JSON document that contains
 
 The table below defines the attributes that describe a bound service. The key for each service in the JSON document is the same as the value of the `label` attribute.
 
-> **Note** Application Service Adapter does not support managed services, so the `label` for a user-provided service instance is always `user-provided`. VMware recommends that apps find connection details through the user-settable `tags` field when parsing `VCAP_SERVICES`.
+> **Note** Application Service Adapter does not support managed services, so the `label` for a user-provided service instance is always `user-provided`. VMware recommends that apps find connection details through the user-settable `tags` field when parsing `VCAP_SERVICES`. Although Application Service Adapter does not support managed services, a user-provided service can be used to supply similar credentials. In these cases existing application code or libraries may expect the credentials to have a specific "label" value. To accommodate these apps, the label of a user-provided service instance can be specified by setting the `spec.serviceLabel` field on its associated `CFServiceInstance` custom resource using the `kubectl` CLI.
 
 | Attribute          | Description                                                                                      |
 | ------------------ | ------------------------------------------------------------------------------------------------ |
@@ -151,6 +151,23 @@ The following example shows the value of the `VCAP_SERVICES` environment variabl
 ~~~
 VCAP_SERVICES=
 {
+  "custom-service-label": [
+    {
+      "binding_guid": "5ef8a506-9c64-4a84-8901-7bb942da8660",
+      "binding_name": null,
+      "credentials": {
+        "sample-config": "sample-value",
+        "type": "user-provided"
+      },
+      "instance_guid": "3b5d58b4-cab3-4b47-b1fa-db204e54fa59",
+      "instance_name": "custom-labeled-service",
+      "label": "custom-service-label",
+      "name": "custom-labeled-service",
+      "syslog_drain_url": null,
+      "tags": [],
+      "volume_mounts": []
+    }
+  ],
   "user-provided": [
     {
       "binding_guid": "65ec345e-4f19-4499-ae70-a32b55c7f1cf",

--- a/environment-variables.md
+++ b/environment-variables.md
@@ -42,31 +42,31 @@ You can access environment variables programmatically, including variables defin
 
 The table below lists the app-specific system environment variables available to your app container. See [App-Specific System Variables](https://docs.pivotal.io/application-service/3-0/devguide/deploy-apps/environment-variable.html#app-system-env) in _TAS for VMs Environment Variables_ for more information on each environment variable.
 
-| Environment Variable | Running | Staging |
-| -------------------- | ------- | ------- |
-| `CF_INSTANCE_ADDR` |  |  |
-| `CF_INSTANCE_GUID` | x |  |
-| `CF_INSTANCE_INDEX` | x |  |
-| `CF_INSTANCE_INTERNAL_IP` | x |  |
-| `CF_INSTANCE_IP` | x |  |
-| `CF_INSTANCE_PORT` |  |  |
-| `CF_INSTANCE_PORTS` |  |  |
-| `CF_STACK` |  |  |
-| `DATABASE_URL` |  |  |
-| `HOME` | x |  |
-| `INSTANCE_GUID` |  |  |
-| `INSTANCE_INDEX` |  |  |
-| `LANG` |  |  |
-| `MEMORY_LIMIT` |  |  |
-| `PATH` | x |  |
-| `PORT` | x |  |
-| `PWD` | x |  |
-| `TMPDIR` |  |  |
-| `USER` |  |  |
-| `VCAP_APP_HOST` | x |  |
-| `VCAP_APP_PORT` | x |  |
-| `VCAP_APPLICATION` |  |  |
-| `VCAP_SERVICES` | x |  |
+| Environment Variable     | Running | Staging |
+|--------------------------|---------| ------- |
+| `CF_INSTANCE_ADDR`       |         |  |
+| `CF_INSTANCE_GUID`       | x       |  |
+| `CF_INSTANCE_INDEX`      | x       |  |
+| `CF_INSTANCE_INTERNAL_IP` | x       |  |
+| `CF_INSTANCE_IP`         | x       |  |
+| `CF_INSTANCE_PORT`       |         |  |
+| `CF_INSTANCE_PORTS`      |         |  |
+| `CF_STACK`               |         |  |
+| `DATABASE_URL`           |         |  |
+| `HOME`                   | x       |  |
+| `INSTANCE_GUID`          |         |  |
+| `INSTANCE_INDEX`         |         |  |
+| `LANG`                   |         |  |
+| `MEMORY_LIMIT`           |         |  |
+| `PATH`                   | x       |  |
+| `PORT`                   | x       |  |
+| `PWD`                    | x       |  |
+| `TMPDIR`                 |         |  |
+| `USER`                   |         |  |
+| `VCAP_APP_HOST`          | x       |  |
+| `VCAP_APP_PORT`          | x       |  |
+| `VCAP_APPLICATION`       | x       |  |
+| `VCAP_SERVICES`          | x       |  |
 
 ### <a id='CF-INSTANCE-GUID'></a> CF_INSTANCE_GUID
 
@@ -118,6 +118,38 @@ Deprecated. Always set to `0.0.0.0`.
 
 Deprecated name for the `PORT` variable.
 
+### <a id='VCAP-APPLICATION'></a> VCAP_APPLICATION
+
+Application Service Adapter provides additional runtime information in the `VCAP_APPLICATION` environment variable.
+The following table lists the attributes that are returned in JSON format.
+
+| Attribute           | Description                                                                                              |
+|---------------------|----------------------------------------------------------------------------------------------------------|
+| `application_id`    | The GUID of the application.                                                                             |
+| `application_name`  | The name of the application.                                                                             |
+| `cf_api`            | The location of the Cloud Foundry API for the Application Service Adapter deployment where the app runs. |
+| `name`              | The name of the application (identical to `application_name`).                                           |
+| `organization_id`   | The GUID identifying the org where the app is deployed.                                                  |
+| `organization_name` | The human-readable name of the org where the app is deployed.                                            |
+| `space_id`          | The GUID identifying the space where the app is deployed.                                                |
+| `space_name`        | The human-readable name of the space where the app is deployed.                                          |
+
+The following example shows the value of the `VCAP_APPLICATION` environment variable:
+
+~~~
+VCAP_APPLICATION=
+{
+  "application_id": "6d36d101-e1ff-4a41-9bc8-c90f2cb329d3",
+  "application_name": "my-application",
+  "cf_api": "https://cf-api.example.com",
+  "name": "my-application",
+  "organization_id": "cf-org-95f15208-a6b6-4491-805c-7d46a4112343",
+  "organization_name": "my-org",
+  "space_id": "cf-space-28e4ede3-6399-45aa-bc4b-862040111814",
+  "space_name": "my-space"
+}
+~~~
+
 ### <a id='VCAP-SERVICES'></a> VCAP_SERVICES
 
 Application Service Adapter has support for user-provided service instances and
@@ -146,7 +178,7 @@ The table below defines the attributes that describe a bound service. The key fo
 | `volume_mounts`    | Not supported.                                                                                   |
 
 
-The following example shows the value of the `VCAP_SERVICES` environment variable for bound instances of user-provided service instances.
+The following example shows the value of the `VCAP_SERVICES` environment variable for bound user-provided service instances.
 
 ~~~
 VCAP_SERVICES=

--- a/getting-started.md
+++ b/getting-started.md
@@ -58,7 +58,7 @@ To create and bind user-provided service instances, do the following:
 1. Create a user-provided service instance containing the credentials necessary for accessing your service:
 
     ```bash
-    cf create-user-provided-service SERVICE-INSTANCE-NAME -p '{"credential-name": "credential-value"}'
+    cf create-user-provided-service SERVICE-INSTANCE-NAME -p '{"credential-name": "credential-value"}' --tags "list, of, optional, tags"
     ```
 
     Where `SERVICE-INSTANCE-NAME` is the name of your service instance.
@@ -75,8 +75,16 @@ To create and bind user-provided service instances, do the following:
     cf restart APP-NAME
     ```
 
-User-provided service instance credentials is provided to the app and staging tasks in two ways to support both existing Tanzu Application Service applications and next-generation frameworks, such as [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings):
+User-provided service instance credentials are provided to the app and staging tasks in two ways to support both existing Tanzu Application Service applications and next-generation frameworks, such as [Spring Cloud Bindings](https://github.com/spring-cloud/spring-cloud-bindings):
 
 * As part of the traditional Cloud Foundry [VCAP_SERVICES environment variable](https://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html#VCAP-SERVICES)
 * As volume mounted secrets in accordance with the [Service Bindings for Kubernetes specification](https://servicebinding.io/spec/core/1.0.0/#workload-projection)
   * This workload projection handles the [Service Bindings Package](https://docs.vmware.com/en/Tanzu-Application-Platform/1.1/tap/GUID-service-bindings-install-service-bindings.html) from Tanzu Application Platform
+
+Applications relying on the `VCAP_SERVICES` presentation of service credentials will typically look up service credential values from using either the "tags" or "labels" field in the payload (see the [environment variables](environment-variables.md) docs for additional details).
+For a user-provided service instance you can specify a list of tags during service creation using the `--tags` flag. The "label" key can be specified by manipulating the corresponding `CFServiceInstance` resource directly using the `kubectl` CLI's `patch` command.
+
+```bash
+kubectl -n $(cf space $SPACE_NAME --guid) patch cfserviceinstance $(cf service $SERVICE_INSTANCE_NAME --guid) \
+--patch '{"spec": {"serviceLabel": "custom-service-label"}}' --type=merge
+```


### PR DESCRIPTION
Update the environment variable docs and getting started docs to include an example of how to use `spec.serviceLabel` on `CFServiceInstance`s to override the service "label" in VCAP_SERVICES.

---

**This applies to `main` and `1.2` (if that branch exists before this is merged)**