### PR TITLE
Add known issue for incorrect cf_api value in VCAP_APPLICATION

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -94,6 +94,8 @@ This release contains the following components:
 
 This release has the following issues:
 
+- The value of the `cf_api` key in the `VCAP_APPLICATION` environment variable is incorrectly set to "https://".
+  As a workaround, the value of the `extraVCAPApplicationValues.cf_api` key can be manually updated in the `korifi-controllers-config` `ConfigMap` resource.
 - If you push an application with a specific buildpack set with the `buildpacks`
   property in the application manifest or with the `-b` flag, that application
   fails to build showing an error that only autodetection of buildpacks is


### PR DESCRIPTION
The `VCAP_APPLICATION` environment variable does not have the correct value for `cf_api`. This change adds that as a known issue which applies to 1.2 (previous releases did not support the `VCAP_APPLICATION` env var at all).

**Backports:** This belongs on both `main` and the `1.2` release branch.