### PR TITLE
Remove instances of TAS Adapter telemetry controller from docs

### DIFF
--- a/install.md
+++ b/install.md
@@ -576,8 +576,6 @@ To configure the scaling parameters for each component of Application Service Ad
        ... #! scaling keys are the same as above
      cartographer_builder_runner:
        ... #! scaling keys are the same as above
-     telemetry_informer:
-       ... #! scaling keys are the same as above
    ```
 
    Where:
@@ -650,51 +648,6 @@ eliminate resources from the cluster.
    - `TASK-TTL-AGE` is the length of time until completed tasks are purged
    from the cluster. You can specify this value as a time duration in seconds,
    minutes, hours, or days. For example, "86400s", "1440m", "24h", or "1d".
-
-### <a id="opt-out-telemetry"></a>(Optional) Opt out of telemetry reporting
-
-When you install Application Service Adapter, you opt into telemetry collection by default. To deactivate telemetry collection, complete the following:
-
-1. Ensure that your Kubernetes context is pointing to the cluster where Application Service Adapter is installed.
-
-2. Run the following kubectl command:
-
-   ```bash
-   kubectl apply -f - <<EOF
-   ---
-   apiVersion: v1
-   kind: Namespace
-   metadata:
-     name: vmware-system-telemetry
-   ---
-   apiVersion: v1
-   kind: ConfigMap
-   metadata:
-     namespace: vmware-system-telemetry
-     name: vmware-telemetry-cluster-ceip
-   data:
-     level: disabled
-   EOF
-   ```
-
-Your Application Service Adapter deployment no longer emits telemetry, and you are opted out of the VMware Customer Experience Improvement Program.
-
-### <a id="telemetry-reporting-interval"></a>(Optional) Configure the telemetry reporting interval:
-
-The default telemetry reporting interval is 24 hours. To change how frequently telemetry data is sent to VMware:
-
-1. Include the following values in your `tas-adapter-values.yaml` file:
-
-   ```yaml
-   telemetry:
-     heartbeat_interval: TELEMETRY-HEARTBEAT-INTERVAL
-   ```
-
-   Where:
-
-   - `TELEMETRY-HEARTBEAT-INTERVAL` is how often telemetry data is sent to
-   VMware. Default is every 24 hours. This value must be specified as a time
-   duration in hours. For example, "24h", not "1d".
 
 ### <a id="user-cert-expiration-warning"></a>(Optional) Configure the user certificate expiration warning duration
 

--- a/overview.md
+++ b/overview.md
@@ -40,6 +40,6 @@ This information cannot directly identify any individual.
 
 You must acknowledge that you have read the VMware CEIP policy before you can proceed with the
 installation.
-For more information, see [Configure the installation settings](install.md#configure-installation-settings) in _Install Application Service Adapter_.
-To opt out of telemetry participation after installation, see
-[Opting out of telemetry reporting](install.md#opt-out-telemetry) in _Install Application Service Adapter_.
+For more information, see [Tanzu Application Platform Telemetry](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/telemetry-overview.html).
+To opt out of CEIP participation after installation, see
+[Opt out of telemetry collection](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.5/tap/opting-out-telemetry.html).

--- a/release-notes.md
+++ b/release-notes.md
@@ -88,7 +88,6 @@ This release contains the following components:
 
 - cartographer-builder-runner @ cb29b8d
 - Korifi @ [v0.7.1](https://github.com/cloudfoundry/korifi/tree/v0.7.1)
-- tas-adapter-telemetry-controller @ 37dda46
 
 ### Known issues
 

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -49,9 +49,7 @@ logs to query when troubleshooting.
    is an excellent starting point when debugging failures. Most commands flow
    through here before being processed by more specific components, with the
    exception of API commands that fail before getting to the controller manager.
-3. The `tas-adapter-telemetry-informer` deployment is tasked with handling all
-   outgoing telemetry.
-4. The `cartographer-builder-runner-controller-manager` deployment is tasked
+3. The `cartographer-builder-runner-controller-manager` deployment is tasked
    with creating Cartographer workloads for apps when using the experimental
    Cartographer builder/runner flow.
 


### PR DESCRIPTION
 - As of TAP v1.6, TAS Adapter telemetry will be integrated into TAP telemetry
 - Left the legal disclaimer for telemetry collection in the overview, but redirected the information and opt out links to TAP v1.5 documentation. These links will have to be updated when TAP v1.6 documentation is available.
 - Removed the TAS Adapter telemetry controller specific troubleshooting and settings
 - Removed the tas-adapter-telemetry-controller from the release notes