### PR TITLE
Document known issue with namespace cleanup for versions <= 1.2

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -103,6 +103,9 @@ This release has the following issues:
   `-b null` on `cf push` to reset the app to use buildpack autodetection. If you
   only remove the field from the manifest or the flag from the `cf push`
   command, the app continues to fail to build.
+- When deleting CF spaces or uninstalling Application Service Adapter the underlying Kubernetes namespaces may not be
+  deleted due to an issue with `ServiceBindingProjection` resource cleanup. As a workaround, you can manually remove the
+  `finalizers` from the `ServiceBindingProjections` to allow namespace deletion to complete.
 - The organization manager role does not have permissions to create Cloud
   Foundry spaces. As a workaround, instead use the Cloud Foundry admin role to
   create spaces in organizations.


### PR DESCRIPTION
Adds a known issue describing orphaned namespaces that can occur CF org/space deletion and TAS Adapter uninstallation due to an issue with the Service Bindings reconciler. 

@HenryBorys I submitted this PR to the `1-2` branch, but this behavior is present in all versions of TAS Adapter <= 1.2 so please cherry-pick this known issue to the `1-1` and `1-0` branches as well. Thanks!