### PR TITLE
:pencil2: Add commentary on OpenShift SCC creation

### DIFF
--- a/install.md
+++ b/install.md
@@ -403,12 +403,14 @@ To configure Application Service Adapter for installation on OpenShift:
 
    - `KUBERNETES-VERSION` is the Kubernetes version of the cluster. Default is `1.23.3`.
 
-2. To force the creation of a custom Application Service Adapter SCC on OpenShift, include the following value in your `tas-adapter-values.yaml` file:
+2. To force the creation of a custom Application Service Adapter Security Context Constraint (SCC) on OpenShift, include the following value in your `tas-adapter-values.yaml` file:
 
    ```yaml
    openshift:
      create_scc: true
    ```
+
+   > **Note** The custom SCC ensures that containers run with a predictable UID of 1000, which is a requirement for workloads created using Application Service Adapter. OpenShift assigns the `restricted` or `restricted-v2` SCCs to workloads deployed using the project's default Kubernetes service account, which means that an arbitrary UID is chosen for container runtime.
 
 ### <a id="aws-iam-registry-auth"></a>(Optional) Use AWS IAM authentication for registry credentials
 


### PR DESCRIPTION
TL;DR
=====
* It wasn't clear to an observer what a custom SCC provides over default functionality in OpenShift; added a small blub to describe it.
* Does it make sense to link to the OpenShift docs?

Detail
======
* The OpenShift documentation provides the following detail around default SCC behavior:

> _The `restricted` and `restricted-v2` SCCs use MustRunAsRange strategy for constraining and defaulting the possible values of the securityContext.runAsUser field. The admission plug-in will look for the `openshift.io/sa.scc.uid-range` annotation on the current project to populate range fields, as it does not provide this range. In the end, a container will have runAsUser equal to the first value of the range that is hard to predict because every project has different ranges._
* [Source](https://docs.openshift.com/container-platform/4.13/authentication/managing-security-context-constraints.html)